### PR TITLE
Feature/just running with corda40

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ lib/dokka.jar
 
 # IntelliJ
 /out/
+**/out/*
 /issuer/out/
 /mock-bank/out/
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,22 +1,31 @@
 buildscript {
     ext.corda_release_group = 'net.corda'
     ext.corda_release_version = '4.0-SNAPSHOT'
-    ext.corda_gradle_plugins_version = '4.0.25'
-    ext.kotlin_version = '1.2.51'
+    ext.corda_gradle_plugins_version = '4.0.36'
+    ext.kotlin_version = '1.2.71'
     ext.junit_version = '4.12'
-    ext.quasar_version = '0.7.9'
+    ext.quasar_version = '0.7.10'
     ext.retrofit_version = '2.4.0'
     ext.okhttp_version = '3.9.1'
     ext.retrofit_version = '2.4.0'
     ext.jopt_simple_version = '5.0.2'
     ext.slf4j_version = '1.7.25'
-    ext.log4j_version = '2.9.1'
+    ext.log4j_version = '2.11.1'
+    ext.artifactory_contextUrl = 'https://ci-artifactory.corda.r3cev.com/artifactory'
 
     repositories {
         mavenLocal()
         mavenCentral()
         jcenter()
-        maven { url 'https://ci-artifactory.corda.r3cev.com/artifactory/list/corda-dev/' }
+        maven {
+            url 'https://kotlin.bintray.com/kotlinx'
+        }
+        maven {
+            url "$artifactory_contextUrl/corda-releases"
+        }
+        maven { 
+            url "$artifactory_contextUrl/list/corda-dev/"
+        }
     }
 
     dependencies {
@@ -101,6 +110,13 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
         apiVersion = "1.2"
         jvmTarget = "1.8"
         javaParameters = true   // Useful for reflection.
+    }
+}
+
+cordapp {
+    info {
+        targetPlatformVersion 4
+        minimumPlatformVersion 4
     }
 }
 

--- a/client/build.gradle
+++ b/client/build.gradle
@@ -68,3 +68,10 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
         javaParameters = true   // Useful for reflection.
     }
 }
+
+cordapp {
+    info {
+        targetPlatformVersion 4
+        minimumPlatformVersion 4
+    }
+}

--- a/client/src/main/kotlin/com/r3/corda/finance/cash/issuer/client/flows/NotifyNostroTransactionHandler.kt
+++ b/client/src/main/kotlin/com/r3/corda/finance/cash/issuer/client/flows/NotifyNostroTransactionHandler.kt
@@ -1,5 +1,6 @@
 package com.r3.corda.finance.cash.issuer.client.flows
 
+import co.paralleluniverse.fibers.Suspendable
 import com.r3.corda.finance.cash.issuer.common.flows.AbstractNotifyNostroTransaction
 import com.r3.corda.finance.cash.issuer.common.types.NostroTransaction
 import net.corda.core.flows.FlowLogic
@@ -9,6 +10,7 @@ import net.corda.core.utilities.unwrap
 
 @InitiatedBy(AbstractNotifyNostroTransaction::class)
 class NotifyNostroTransactionHandler(val otherSession: FlowSession) : FlowLogic<NostroTransaction>() {
+    @Suspendable
     override fun call(): NostroTransaction {
         return otherSession.receive<NostroTransaction>().unwrap { it }
     }

--- a/client/src/main/kotlin/com/r3/corda/finance/cash/issuer/client/flows/ReceiveIssuedCash.kt
+++ b/client/src/main/kotlin/com/r3/corda/finance/cash/issuer/client/flows/ReceiveIssuedCash.kt
@@ -1,0 +1,19 @@
+package com.r3.corda.finance.cash.issuer.client.flows
+
+import co.paralleluniverse.fibers.Suspendable
+import com.r3.corda.finance.cash.issuer.common.flows.AbstractIssueCash
+import net.corda.core.flows.*
+import net.corda.core.node.StatesToRecord
+import net.corda.core.transactions.SignedTransaction
+
+@InitiatedBy(AbstractIssueCash::class)
+class ReceiveIssuedCash(val otherSession: FlowSession) : FlowLogic<Unit>() {
+    @Suspendable
+    override fun call() {
+        logger.info("Starting ReceiveIssuedCash flow...")
+        //return subFlow(ReceiveTransactionFlow(otherSession, true, StatesToRecord.ALL_VISIBLE))
+        if (!serviceHub.myInfo.isLegalIdentity(otherSession.counterparty)) {
+            subFlow(ReceiveFinalityFlow(otherSession))
+        }
+    }
+}

--- a/client/src/main/kotlin/com/r3/corda/finance/cash/issuer/client/flows/ReceiveVerifyBankAccount.kt
+++ b/client/src/main/kotlin/com/r3/corda/finance/cash/issuer/client/flows/ReceiveVerifyBankAccount.kt
@@ -1,0 +1,20 @@
+package com.r3.corda.finance.cash.issuer.client.flows
+
+import co.paralleluniverse.fibers.Suspendable
+import com.r3.corda.finance.cash.issuer.common.flows.AbstractVerifyBankAccount
+import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.FlowSession
+import net.corda.core.flows.InitiatedBy
+import net.corda.core.flows.ReceiveFinalityFlow
+
+@InitiatedBy(AbstractVerifyBankAccount::class)
+class ReceiveVerifyBankAccount(val otherSession: FlowSession) : FlowLogic<Unit>() {
+    @Suspendable
+    override fun call() {
+        logger.info("Starting ReceiveVerifyBankAccount flow...")
+        //return subFlow(ReceiveTransactionFlow(otherSession, true, StatesToRecord.ALL_VISIBLE))
+        if (!serviceHub.myInfo.isLegalIdentity(otherSession.counterparty)) {
+            subFlow(ReceiveFinalityFlow(otherSession))
+        }
+    }
+}

--- a/client/src/main/kotlin/com/r3/corda/finance/cash/issuer/client/flows/RedeemCash.kt
+++ b/client/src/main/kotlin/com/r3/corda/finance/cash/issuer/client/flows/RedeemCash.kt
@@ -10,7 +10,8 @@ import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.utilities.OpaqueBytes
 import net.corda.core.utilities.ProgressTracker
-import net.corda.finance.contracts.asset.cash.selection.AbstractCashSelection
+import net.corda.finance.contracts.asset.AbstractCashSelection
+
 import net.corda.finance.issuedBy
 import java.util.*
 
@@ -33,7 +34,7 @@ class RedeemCash(val amount: Amount<Currency>, val issuer: Party) : AbstractRede
         val exitStates = AbstractCashSelection
                 .getInstance { serviceHub.jdbcSession().metaData }
                 .unconsumedCashStatesForSpending(serviceHub, amount, setOf(issuer), builder.notary, builder.lockId, setOf())
-        exitStates.forEach { logger.info(it.state.data.toString()) }
+        //exitStates.forEach { logger.info(it.state.data.toString()) }
 
         progressTracker.currentStep = REDEEMING
         val otherSession = initiateFlow(issuer)

--- a/client/src/main/kotlin/com/r3/corda/finance/cash/issuer/client/flows/RedeemCash.kt
+++ b/client/src/main/kotlin/com/r3/corda/finance/cash/issuer/client/flows/RedeemCash.kt
@@ -4,10 +4,7 @@ import co.paralleluniverse.fibers.Suspendable
 import com.r3.corda.finance.cash.issuer.common.flows.AbstractRedeemCash
 import net.corda.core.contracts.Amount
 import net.corda.core.contracts.PartyAndReference
-import net.corda.core.flows.SendStateAndRefFlow
-import net.corda.core.flows.SignTransactionFlow
-import net.corda.core.flows.StartableByRPC
-import net.corda.core.flows.StartableByService
+import net.corda.core.flows.*
 import net.corda.core.identity.Party
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.TransactionBuilder
@@ -19,10 +16,12 @@ import java.util.*
 
 @StartableByRPC
 @StartableByService
+@InitiatingFlow
 class RedeemCash(val amount: Amount<Currency>, val issuer: Party) : AbstractRedeemCash() {
 
     companion object {
         object REDEEMING : ProgressTracker.Step("Redeeming cash.")
+        @JvmStatic
         fun tracker() = ProgressTracker(REDEEMING)
     }
 

--- a/client/src/main/kotlin/com/r3/corda/finance/cash/issuer/client/flows/RedeemCash.kt
+++ b/client/src/main/kotlin/com/r3/corda/finance/cash/issuer/client/flows/RedeemCash.kt
@@ -16,7 +16,6 @@ import java.util.*
 
 @StartableByRPC
 @StartableByService
-@InitiatingFlow
 class RedeemCash(val amount: Amount<Currency>, val issuer: Party) : AbstractRedeemCash() {
 
     companion object {

--- a/client/src/main/kotlin/com/r3/corda/finance/cash/issuer/client/flows/SendBankAccount.kt
+++ b/client/src/main/kotlin/com/r3/corda/finance/cash/issuer/client/flows/SendBankAccount.kt
@@ -22,6 +22,7 @@ class SendBankAccount(val issuer: Party, val linearId: UniqueIdentifier) : Abstr
     companion object {
         object SENDING : ProgressTracker.Step("Sending to issuer.")
 
+        @JvmStatic
         fun tracker() = ProgressTracker(SENDING)
     }
 

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -67,3 +67,10 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
         javaParameters = true   // Useful for reflection.
     }
 }
+
+cordapp {
+    info {
+        targetPlatformVersion 4
+        minimumPlatformVersion 4
+    }
+}

--- a/common/src/main/kotlin/com/r3/corda/finance/cash/issuer/common/flows/AbstractIssueCash.kt
+++ b/common/src/main/kotlin/com/r3/corda/finance/cash/issuer/common/flows/AbstractIssueCash.kt
@@ -1,0 +1,8 @@
+package com.r3.corda.finance.cash.issuer.common.flows
+
+import net.corda.core.flows.InitiatingFlow
+import net.corda.core.utilities.ProgressTracker
+import net.corda.finance.flows.AbstractCashFlow
+
+@InitiatingFlow
+abstract class AbstractIssueCash<out T>(override val progressTracker: ProgressTracker) : AbstractCashFlow<T>(progressTracker)

--- a/common/src/main/kotlin/com/r3/corda/finance/cash/issuer/common/flows/AbstractVerifyBankAccount.kt
+++ b/common/src/main/kotlin/com/r3/corda/finance/cash/issuer/common/flows/AbstractVerifyBankAccount.kt
@@ -1,0 +1,10 @@
+package com.r3.corda.finance.cash.issuer.common.flows
+
+import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.InitiatingFlow
+import net.corda.core.transactions.SignedTransaction
+
+@InitiatingFlow
+abstract class AbstractVerifyBankAccount : FlowLogic<SignedTransaction>() {
+
+}

--- a/common/src/main/kotlin/com/r3/corda/finance/cash/issuer/common/flows/AddBankAccount.kt
+++ b/common/src/main/kotlin/com/r3/corda/finance/cash/issuer/common/flows/AddBankAccount.kt
@@ -18,12 +18,14 @@ import net.corda.core.utilities.ProgressTracker
  */
 @StartableByRPC
 @StartableByService
+@InitiatingFlow
 class AddBankAccount(val bankAccount: BankAccount) : FlowLogic<SignedTransaction>() {
 
     companion object {
         // TODO: Add the rest of the progress tracker.
         object FINALISING : ProgressTracker.Step("Finalising transaction.")
 
+        @JvmStatic
         fun tracker() = ProgressTracker(FINALISING)
     }
 

--- a/common/src/main/kotlin/com/r3/corda/finance/cash/issuer/common/flows/AddBankAccount.kt
+++ b/common/src/main/kotlin/com/r3/corda/finance/cash/issuer/common/flows/AddBankAccount.kt
@@ -7,10 +7,7 @@ import com.r3.corda.finance.cash.issuer.common.types.toState
 import com.r3.corda.finance.cash.issuer.common.utilities.getBankAccountStateByAccountNumber
 import net.corda.core.contracts.Command
 import net.corda.core.contracts.StateAndContract
-import net.corda.core.flows.FinalityFlow
-import net.corda.core.flows.FlowLogic
-import net.corda.core.flows.StartableByRPC
-import net.corda.core.flows.StartableByService
+import net.corda.core.flows.*
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.utilities.ProgressTracker
@@ -57,7 +54,7 @@ class AddBankAccount(val bankAccount: BankAccount) : FlowLogic<SignedTransaction
         val signedTransaction = serviceHub.signInitialTransaction(unsignedTransaction)
 
         progressTracker.currentStep = FINALISING
-        return subFlow(FinalityFlow(signedTransaction))
+        return subFlow(FinalityFlow(signedTransaction, emptySet<FlowSession>()))
     }
 
 }

--- a/common/src/main/kotlin/com/r3/corda/finance/cash/issuer/common/flows/MoveCash.kt
+++ b/common/src/main/kotlin/com/r3/corda/finance/cash/issuer/common/flows/MoveCash.kt
@@ -5,6 +5,7 @@ import net.corda.core.contracts.Amount
 import net.corda.core.contracts.InsufficientBalanceException
 import net.corda.core.flows.FinalityFlow
 import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.FlowSession
 import net.corda.core.flows.StartableByRPC
 import net.corda.core.identity.Party
 import net.corda.core.transactions.SignedTransaction
@@ -43,6 +44,6 @@ class MoveCash(val recipient: Party, val amount: Amount<Currency>) : FlowLogic<S
         logger.info(transactionBuilder.toWireTransaction(serviceHub).toString())
         val signedTransaction = serviceHub.signInitialTransaction(transactionBuilder, keys)
         progressTracker.currentStep = MOVING
-        return subFlow(FinalityFlow(signedTransaction))
+        return subFlow(FinalityFlow(signedTransaction, emptySet<FlowSession>()))
     }
 }

--- a/common/src/main/kotlin/com/r3/corda/finance/cash/issuer/common/flows/MoveCash.kt
+++ b/common/src/main/kotlin/com/r3/corda/finance/cash/issuer/common/flows/MoveCash.kt
@@ -25,6 +25,7 @@ class MoveCash(val recipient: Party, val amount: Amount<Currency>) : FlowLogic<S
         // TODO: Add the rest of the progress tracker.
         object MOVING : ProgressTracker.Step("Moving cash.")
 
+        @JvmStatic
         fun tracker() = ProgressTracker(MOVING)
     }
 

--- a/common/src/main/kotlin/com/r3/corda/finance/cash/issuer/common/states/BankAccountState.kt
+++ b/common/src/main/kotlin/com/r3/corda/finance/cash/issuer/common/states/BankAccountState.kt
@@ -1,8 +1,10 @@
 package com.r3.corda.finance.cash.issuer.common.states
 
+import com.r3.corda.finance.cash.issuer.common.contracts.BankAccountContract
 import com.r3.corda.finance.cash.issuer.common.schemas.BankAccountStateSchemaV1
 import com.r3.corda.finance.cash.issuer.common.types.AccountNumber
 import com.r3.corda.finance.cash.issuer.common.types.BankAccountType
+import net.corda.core.contracts.BelongsToContract
 import net.corda.core.contracts.LinearState
 import net.corda.core.contracts.UniqueIdentifier
 import net.corda.core.identity.AbstractParty
@@ -16,6 +18,7 @@ import java.util.*
 // TODO: Maybe change verified property to whitelisted.
 // The same principle applies to all accounts, customers and issuers.
 // Only match transactions once the accounts have been verified/whitelisted.
+@BelongsToContract(BankAccountContract::class)
 data class BankAccountState(
         val owner: Party,
         val accountName: String,

--- a/common/src/main/kotlin/com/r3/corda/finance/cash/issuer/common/states/NodeTransactionState.kt
+++ b/common/src/main/kotlin/com/r3/corda/finance/cash/issuer/common/states/NodeTransactionState.kt
@@ -1,9 +1,11 @@
 package com.r3.corda.finance.cash.issuer.common.states
 
+import com.r3.corda.finance.cash.issuer.common.contracts.NodeTransactionContract
 import com.r3.corda.finance.cash.issuer.common.schemas.NodeTransactionStateSchemaV1
 import com.r3.corda.finance.cash.issuer.common.types.NodeTransactionStatus
 import com.r3.corda.finance.cash.issuer.common.types.NodeTransactionType
 import net.corda.core.contracts.AmountTransfer
+import net.corda.core.contracts.BelongsToContract
 import net.corda.core.contracts.LinearState
 import net.corda.core.contracts.UniqueIdentifier
 import net.corda.core.identity.AbstractParty
@@ -14,6 +16,7 @@ import net.corda.core.schemas.QueryableState
 import java.time.Instant
 import java.util.*
 
+@BelongsToContract(NodeTransactionContract::class)
 data class NodeTransactionState(
         val amountTransfer: AmountTransfer<Currency, Party>,
         val createdAt: Instant,

--- a/common/src/main/kotlin/com/r3/corda/finance/cash/issuer/common/states/NostroTransactionState.kt
+++ b/common/src/main/kotlin/com/r3/corda/finance/cash/issuer/common/states/NostroTransactionState.kt
@@ -1,10 +1,12 @@
 package com.r3.corda.finance.cash.issuer.common.states
 
+import com.r3.corda.finance.cash.issuer.common.contracts.NostroTransactionContract
 import com.r3.corda.finance.cash.issuer.common.schemas.NostroTransactionStateSchemaV1
 import com.r3.corda.finance.cash.issuer.common.types.AccountNumber
 import com.r3.corda.finance.cash.issuer.common.types.NostroTransactionStatus
 import com.r3.corda.finance.cash.issuer.common.types.NostroTransactionType
 import net.corda.core.contracts.AmountTransfer
+import net.corda.core.contracts.BelongsToContract
 import net.corda.core.contracts.LinearState
 import net.corda.core.contracts.UniqueIdentifier
 import net.corda.core.identity.AbstractParty
@@ -15,6 +17,7 @@ import net.corda.core.schemas.QueryableState
 import java.time.Instant
 import java.util.*
 
+@BelongsToContract(NostroTransactionContract::class)
 data class NostroTransactionState(
         val accountId: String,
         val amountTransfer: AmountTransfer<Currency, AccountNumber>,

--- a/daemon/build.gradle
+++ b/daemon/build.gradle
@@ -68,7 +68,7 @@ dependencies {
     cordaRuntime "$corda_release_group:corda:$corda_release_version"
 
     // Class path scanning.
-    compile "io.github.lukehutch:fast-classpath-scanner:3.1.15"
+    compile "io.github.classgraph:classgraph:4.1.12"
 
     // JOpt: for command line flags.
     compile "net.sf.jopt-simple:jopt-simple:$jopt_simple_version"
@@ -101,6 +101,16 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
         apiVersion = "1.2"
         jvmTarget = "1.8"
         javaParameters = true   // Useful for reflection.
+    }
+}
+
+cordapp {
+    info {
+        targetPlatformVersion 4
+        minimumPlatformVersion 4
+    }
+    signing {
+        enabled false
     }
 }
 

--- a/daemon/config/dev/log4j2.xml
+++ b/daemon/config/dev/log4j2.xml
@@ -13,8 +13,7 @@
         <Console name="Console-Appender" target="SYSTEM_OUT">
             <PatternLayout>
                 <pattern>
-                    %highlight{%level{length=1} %d{HH:mm:ss} %T %c{1}.%M - %msg%n}{INFO=white,WARN=red,FATAL=bright red
-                    blink}
+                    %highlight{%level{length=1} %d{HH:mm:ss} %T %c{1}.%M - %msg%n}{INFO=white,WARN=red,FATAL=bright red blink}
                 </pattern>>
             </PatternLayout>
         </Console>

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -69,3 +69,10 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
         javaParameters = true   // Useful for reflection.
     }
 }
+
+cordapp {
+    info {
+        targetPlatformVersion 4
+        minimumPlatformVersion 4
+    }
+}

--- a/service/src/main/kotlin/com/r3/corda/finance/cash/issuer/service/flows/AddNostroTransactions.kt
+++ b/service/src/main/kotlin/com/r3/corda/finance/cash/issuer/service/flows/AddNostroTransactions.kt
@@ -9,6 +9,7 @@ import com.r3.corda.finance.cash.issuer.common.utilities.getNostroTransactionSta
 import net.corda.core.contracts.Command
 import net.corda.core.flows.FinalityFlow
 import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.FlowSession
 import net.corda.core.flows.StartableByRPC
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.utilities.ProgressTracker
@@ -42,6 +43,7 @@ class AddNostroTransactions(val newNostroTransactions: List<NostroTransaction>) 
         // This should really be checked on the RPC client side but just double checking it here
         // as well, otherwise we'll end up trying to commit transactions with no output states!
         logger.info("Starting AddNostroTransaction flow...")
+
         newNostroTransactions.forEach { logger.info(it.toString()) }
 
         if (newNostroTransactions.isEmpty()) {
@@ -73,7 +75,7 @@ class AddNostroTransactions(val newNostroTransactions: List<NostroTransaction>) 
 
         val signedTransaction = serviceHub.signInitialTransaction(unsignedTransaction)
         progressTracker.currentStep = FINALISING
-        val finalisedTransaction = subFlow(FinalityFlow(signedTransaction, FINALISING.childProgressTracker()))
+        val finalisedTransaction = subFlow(FinalityFlow(signedTransaction, emptySet<FlowSession>(), FINALISING.childProgressTracker()))
 
         // The flow returns the IDs and timestamps of the last updates for each nostro account so
         // the daemon knows what has been recorded to date.

--- a/service/src/main/kotlin/com/r3/corda/finance/cash/issuer/service/flows/AddNostroTransactions.kt
+++ b/service/src/main/kotlin/com/r3/corda/finance/cash/issuer/service/flows/AddNostroTransactions.kt
@@ -7,10 +7,7 @@ import com.r3.corda.finance.cash.issuer.common.types.NostroTransaction
 import com.r3.corda.finance.cash.issuer.common.types.toState
 import com.r3.corda.finance.cash.issuer.common.utilities.getNostroTransactionStateByTransactionId
 import net.corda.core.contracts.Command
-import net.corda.core.flows.FinalityFlow
-import net.corda.core.flows.FlowLogic
-import net.corda.core.flows.FlowSession
-import net.corda.core.flows.StartableByRPC
+import net.corda.core.flows.*
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.utilities.ProgressTracker
 import java.time.Instant
@@ -24,6 +21,7 @@ import java.time.Instant
  * daemon process with the transactions which have been committed up to this point.
  */
 @StartableByRPC
+@InitiatingFlow
 class AddNostroTransactions(val newNostroTransactions: List<NostroTransaction>) : FlowLogic<Map<String, Instant>>() {
 
     companion object {
@@ -32,6 +30,7 @@ class AddNostroTransactions(val newNostroTransactions: List<NostroTransaction>) 
             override fun childProgressTracker() = FinalityFlow.tracker()
         }
 
+        @JvmStatic
         fun tracker() = ProgressTracker(FINALISING)
     }
 

--- a/service/src/main/kotlin/com/r3/corda/finance/cash/issuer/service/flows/GetNostroAccountBalances.kt
+++ b/service/src/main/kotlin/com/r3/corda/finance/cash/issuer/service/flows/GetNostroAccountBalances.kt
@@ -1,10 +1,12 @@
 package com.r3.corda.finance.cash.issuer.service.flows
 
+import co.paralleluniverse.fibers.Suspendable
 import com.r3.corda.finance.cash.issuer.common.utilities.getNostroAccountBalances
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.StartableByRPC
 
 @StartableByRPC
 class GetNostroAccountBalances : FlowLogic<Map<String, Long>>() {
+    @Suspendable
     override fun call() = getNostroAccountBalances(serviceHub)
 }

--- a/service/src/main/kotlin/com/r3/corda/finance/cash/issuer/service/flows/IssueCash.kt
+++ b/service/src/main/kotlin/com/r3/corda/finance/cash/issuer/service/flows/IssueCash.kt
@@ -7,6 +7,7 @@ import com.r3.corda.finance.cash.issuer.common.types.NodeTransactionStatus
 import net.corda.core.contracts.Amount
 import net.corda.core.flows.FinalityFlow
 import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.FlowSession
 import net.corda.core.flows.StartableByService
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.TransactionBuilder
@@ -34,7 +35,7 @@ class IssueCash(val stx: SignedTransaction) : FlowLogic<Pair<SignedTransaction, 
                 .addOutputState(nodeTransactionState.copy(status = NodeTransactionStatus.COMPLETE), NodeTransactionContract.CONTRACT_ID)
 
         val signedTransaction = serviceHub.signInitialTransaction(internalBuilder)
-        val internalFtx = subFlow(FinalityFlow(signedTransaction))
+        val internalFtx = subFlow(FinalityFlow(signedTransaction, emptySet<FlowSession>()))
 
         /** Commit the cash issuance transaction. */
         val externalFtx = subFlow(IssueCashInternal(

--- a/service/src/main/kotlin/com/r3/corda/finance/cash/issuer/service/flows/IssueCash.kt
+++ b/service/src/main/kotlin/com/r3/corda/finance/cash/issuer/service/flows/IssueCash.kt
@@ -9,6 +9,8 @@ import net.corda.core.flows.*
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.utilities.OpaqueBytes
+import net.corda.core.utilities.ProgressTracker
+import net.corda.finance.flows.AbstractCashFlow
 import net.corda.finance.flows.CashIssueAndPaymentFlow
 import net.corda.finance.flows.CashIssueFlow
 
@@ -21,31 +23,55 @@ import net.corda.finance.flows.CashIssueFlow
 @InitiatingFlow
 @StartableByService
 class IssueCash(val stx: SignedTransaction) : FlowLogic<Pair<SignedTransaction, SignedTransaction>>() {
+    companion object {
+        object GENERATING_TX : ProgressTracker.Step("Generating node transaction")
+        object SIGNING_TX : ProgressTracker.Step("Signing node transaction")
+        object FINALISING_TX : ProgressTracker.Step("Obtaining notary signature and recording node transaction") {
+            override fun childProgressTracker() = FinalityFlow.tracker()
+        }
+        object ISSUE_CASH : ProgressTracker.Step("Issue cash internal") {
+            override fun childProgressTracker() = AbstractCashFlow.tracker()
+        }
 
+
+        @JvmStatic
+        fun tracker() = ProgressTracker(
+                GENERATING_TX,
+                SIGNING_TX,
+                FINALISING_TX,
+                ISSUE_CASH
+        )
+    }
+
+    override val progressTracker = tracker()
     @Suspendable
     override fun call(): Pair<SignedTransaction, SignedTransaction> {
         // Our chosen notary.
         val notary = serviceHub.networkMapCache.notaryIdentities.first()
-
         val nodeTransactionStateAndRef = stx.tx.outRefsOfType<NodeTransactionState>().single()
         val nodeTransactionState = nodeTransactionStateAndRef.state.data
 
+        progressTracker.currentStep = GENERATING_TX
         // TODO: Check that the bank account states are verified.
         val internalBuilder = TransactionBuilder(notary = notary)
                 .addCommand(NodeTransactionContract.Update(), listOf(ourIdentity.owningKey))
                 .addInputState(nodeTransactionStateAndRef)
                 .addOutputState(nodeTransactionState.copy(status = NodeTransactionStatus.COMPLETE), NodeTransactionContract.CONTRACT_ID)
 
+        progressTracker.currentStep = SIGNING_TX
         val signedTransaction = serviceHub.signInitialTransaction(internalBuilder)
-        val internalFtx = subFlow(FinalityFlow(signedTransaction, emptySet<FlowSession>()))
+
+        progressTracker.currentStep = FINALISING_TX
+        val internalFtx = subFlow(FinalityFlow(signedTransaction, emptySet<FlowSession>(), FINALISING_TX.childProgressTracker()))
 
         /** Commit the cash issuance transaction. */
+        progressTracker.currentStep = ISSUE_CASH
         val recipient = nodeTransactionState.amountTransfer.destination
         val amount = Amount(nodeTransactionState.amountTransfer.quantityDelta, nodeTransactionState.amountTransfer.token)
+        //val externalFtx = subFlow(CashIssueAndPaymentFlow(amount, OpaqueBytes.of(0), recipient, false, notary))
+        val externalRes = subFlow(IssueCashInternal(recipient, amount, ISSUE_CASH.childProgressTracker()))
 
-        val externalFtx = subFlow(CashIssueAndPaymentFlow(amount, OpaqueBytes.of(0), recipient, false, notary))
-
-        return Pair(internalFtx, externalFtx.stx)
+        return Pair(internalFtx, externalRes.stx)
     }
 
 }

--- a/service/src/main/kotlin/com/r3/corda/finance/cash/issuer/service/flows/IssueCash.kt
+++ b/service/src/main/kotlin/com/r3/corda/finance/cash/issuer/service/flows/IssueCash.kt
@@ -5,18 +5,20 @@ import com.r3.corda.finance.cash.issuer.common.contracts.NodeTransactionContract
 import com.r3.corda.finance.cash.issuer.common.states.NodeTransactionState
 import com.r3.corda.finance.cash.issuer.common.types.NodeTransactionStatus
 import net.corda.core.contracts.Amount
-import net.corda.core.flows.FinalityFlow
-import net.corda.core.flows.FlowLogic
-import net.corda.core.flows.FlowSession
-import net.corda.core.flows.StartableByService
+import net.corda.core.flows.*
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.TransactionBuilder
+import net.corda.core.utilities.OpaqueBytes
+import net.corda.finance.flows.CashIssueAndPaymentFlow
+import net.corda.finance.flows.CashIssueFlow
+
 
 // TODO: Denominations? E.g. 100 split between 10 issuances of 10.
 // TODO: Ask the counterparty for a random key and issue to that key.
 // TODO: Move all tx generation stuff to the common library.
 // TODO: Add the option for issuing to anonymous public keys.
 
+@InitiatingFlow
 @StartableByService
 class IssueCash(val stx: SignedTransaction) : FlowLogic<Pair<SignedTransaction, SignedTransaction>>() {
 
@@ -38,11 +40,12 @@ class IssueCash(val stx: SignedTransaction) : FlowLogic<Pair<SignedTransaction, 
         val internalFtx = subFlow(FinalityFlow(signedTransaction, emptySet<FlowSession>()))
 
         /** Commit the cash issuance transaction. */
-        val externalFtx = subFlow(IssueCashInternal(
-                to = nodeTransactionState.amountTransfer.destination,
-                amount = Amount(nodeTransactionState.amountTransfer.quantityDelta, nodeTransactionState.amountTransfer.token)
-        ))
-        return Pair(internalFtx, externalFtx)
+        val recipient = nodeTransactionState.amountTransfer.destination
+        val amount = Amount(nodeTransactionState.amountTransfer.quantityDelta, nodeTransactionState.amountTransfer.token)
+
+        val externalFtx = subFlow(CashIssueAndPaymentFlow(amount, OpaqueBytes.of(0), recipient, false, notary))
+
+        return Pair(internalFtx, externalFtx.stx)
     }
 
 }

--- a/service/src/main/kotlin/com/r3/corda/finance/cash/issuer/service/flows/IssueCashInternal.kt
+++ b/service/src/main/kotlin/com/r3/corda/finance/cash/issuer/service/flows/IssueCashInternal.kt
@@ -10,6 +10,10 @@ import net.corda.core.utilities.OpaqueBytes
 import net.corda.core.utilities.ProgressTracker
 import net.corda.finance.contracts.asset.Cash
 import net.corda.finance.flows.AbstractCashFlow
+import net.corda.finance.flows.AbstractCashFlow.Companion.FINALISING_TX
+import net.corda.finance.flows.AbstractCashFlow.Companion.GENERATING_ID
+import net.corda.finance.flows.AbstractCashFlow.Companion.GENERATING_TX
+import net.corda.finance.flows.AbstractCashFlow.Companion.SIGNING_TX
 import net.corda.finance.issuedBy
 import java.util.*
 

--- a/service/src/main/kotlin/com/r3/corda/finance/cash/issuer/service/flows/IssueCashInternal.kt
+++ b/service/src/main/kotlin/com/r3/corda/finance/cash/issuer/service/flows/IssueCashInternal.kt
@@ -7,6 +7,7 @@ import net.corda.core.contracts.Issued
 import net.corda.core.contracts.PartyAndReference
 import net.corda.core.flows.FinalityFlow
 import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.FlowSession
 import net.corda.core.identity.AbstractParty
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.TransactionBuilder
@@ -39,6 +40,6 @@ class IssueCashInternal(val to: AbstractParty, val amount: Amount<Currency>) : F
 
         // Sign and finalise.
         val externalStx = serviceHub.signInitialTransaction(externalBuilder)
-        return subFlow(FinalityFlow(externalStx))
+        return subFlow(FinalityFlow(externalStx, emptySet<FlowSession>()))
     }
 }

--- a/service/src/main/kotlin/com/r3/corda/finance/cash/issuer/service/flows/IssueCashInternal.kt
+++ b/service/src/main/kotlin/com/r3/corda/finance/cash/issuer/service/flows/IssueCashInternal.kt
@@ -1,45 +1,43 @@
 package com.r3.corda.finance.cash.issuer.service.flows
 
 import co.paralleluniverse.fibers.Suspendable
+import com.r3.corda.finance.cash.issuer.common.flows.AbstractIssueCash
 import net.corda.core.contracts.Amount
-import net.corda.core.contracts.Command
-import net.corda.core.contracts.Issued
-import net.corda.core.contracts.PartyAndReference
-import net.corda.core.flows.FinalityFlow
-import net.corda.core.flows.FlowLogic
-import net.corda.core.flows.FlowSession
-import net.corda.core.identity.AbstractParty
-import net.corda.core.transactions.SignedTransaction
+import net.corda.core.flows.*
+import net.corda.core.identity.Party
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.utilities.OpaqueBytes
+import net.corda.core.utilities.ProgressTracker
 import net.corda.finance.contracts.asset.Cash
+import net.corda.finance.flows.AbstractCashFlow
+import net.corda.finance.issuedBy
 import java.util.*
 
-class IssueCashInternal(val to: AbstractParty, val amount: Amount<Currency>) : FlowLogic<SignedTransaction>() {
+
+class IssueCashInternal(val recipient: Party,
+                        val amount: Amount<Currency>,
+                        override val progressTracker: ProgressTracker) : AbstractIssueCash<AbstractCashFlow.Result>(progressTracker) {
     @Suspendable
-    override fun call(): SignedTransaction {
+    override fun call(): AbstractCashFlow.Result {
+        progressTracker.currentStep = GENERATING_ID
+        val recipientSession = initiateFlow(recipient)
         val notary = serviceHub.networkMapCache.notaryIdentities.first()
-        val command = Command(Cash.Commands.Issue(), listOf(ourIdentity.owningKey))
-        // Create a new cash state.
-        // The issuer reference is the hash of the transaction containing the nostro transaction state which led to
-        // this issuance. We include this so we can check it during redemption time. Using this as the reference means
-        // that cash states won't get merged very often as it's likely that the reference is different (one for each
-        // issuance).
-        // TODO: Issuer references is a dud concept. We should deprecate it in Corda Core.
-        val partyAndReference = PartyAndReference(ourIdentity, OpaqueBytes.of(0))
-        val issuerAndToken = Issued(partyAndReference, amount.token)
-        val issuedAmount = Amount(amount.quantity, issuerAndToken)
-        val cashState = Cash.State(
-                amount = issuedAmount,
-                owner = to
-        )
+        val builder = TransactionBuilder(notary = notary)
 
-        val externalBuilder = TransactionBuilder(notary = notary)
-                .addOutputState(cashState, Cash.PROGRAM_ID)
-                .addCommand(command)
+        progressTracker.currentStep = GENERATING_TX
+        logger.info("Generating issue for: ${builder.lockId}")
+        val issuer = ourIdentity.ref(OpaqueBytes.of(0))
+        val signers = Cash().generateIssue(builder, amount.issuedBy(issuer), recipient, notary)
 
-        // Sign and finalise.
-        val externalStx = serviceHub.signInitialTransaction(externalBuilder)
-        return subFlow(FinalityFlow(externalStx, emptySet<FlowSession>()))
+        progressTracker.currentStep = SIGNING_TX
+        logger.info("Signing transaction for: ${builder.lockId}")
+        val tx = serviceHub.signInitialTransaction(builder, signers)
+
+        progressTracker.currentStep = FINALISING_TX
+        logger.info("Finalising transaction for: ${tx.id}")
+        val sessionsForFinality = if (serviceHub.myInfo.isLegalIdentity(recipient)) emptyList() else listOf(recipientSession)
+        val notarisedTx = finaliseTx(tx, sessionsForFinality, "Unable to notarise spend")
+        logger.info("Finalised transaction for: ${notarisedTx.id}")
+        return Result(notarisedTx, recipient)
     }
 }

--- a/service/src/main/kotlin/com/r3/corda/finance/cash/issuer/service/flows/ProcessNostroTransaction.kt
+++ b/service/src/main/kotlin/com/r3/corda/finance/cash/issuer/service/flows/ProcessNostroTransaction.kt
@@ -30,12 +30,14 @@ import java.time.Instant
  * TODO This flow should probably be called MatchNostroTransactionFlow
  */
 @StartableByService
+@InitiatingFlow
 class ProcessNostroTransaction(val stateAndRef: StateAndRef<NostroTransactionState>) : FlowLogic<SignedTransaction>() {
 
     /**
      * Updates the status of the nostro transaction state. Doesn't add anything else. No return type as the builder is
      * mutable.
      */
+    @Suspendable
     private fun createBaseTransaction(builder: TransactionBuilder, newType: NostroTransactionType, newStatus: NostroTransactionStatus) {
         val command = Command(NostroTransactionContract.Match(), listOf(ourIdentity.owningKey))
         val nostroTransactionOutput = stateAndRef.state.data.copy(type = newType, status = newStatus)
@@ -45,6 +47,7 @@ class ProcessNostroTransaction(val stateAndRef: StateAndRef<NostroTransactionSta
                 .addOutputState(nostroTransactionOutput, NostroTransactionContract.CONTRACT_ID)
     }
 
+    @Suspendable
     private fun addNodeTransactionState(
             builder: TransactionBuilder,
             bankAccountStates: List<StateAndRef<BankAccountState>>,

--- a/service/src/main/kotlin/com/r3/corda/finance/cash/issuer/service/flows/ProcessNostroTransaction.kt
+++ b/service/src/main/kotlin/com/r3/corda/finance/cash/issuer/service/flows/ProcessNostroTransaction.kt
@@ -15,10 +15,7 @@ import com.r3.corda.finance.cash.issuer.common.utilities.getPendingRedemptionByN
 import net.corda.core.contracts.AmountTransfer
 import net.corda.core.contracts.Command
 import net.corda.core.contracts.StateAndRef
-import net.corda.core.flows.FinalityFlow
-import net.corda.core.flows.FlowException
-import net.corda.core.flows.FlowLogic
-import net.corda.core.flows.StartableByService
+import net.corda.core.flows.*
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.TransactionBuilder
 import java.time.Instant
@@ -168,7 +165,7 @@ class ProcessNostroTransaction(val stateAndRef: StateAndRef<NostroTransactionSta
         }
 
         val stx = serviceHub.signInitialTransaction(builder)
-        return subFlow(FinalityFlow(stx))
+        return subFlow(FinalityFlow(stx, emptySet<FlowSession>()))
     }
 
 }

--- a/service/src/main/kotlin/com/r3/corda/finance/cash/issuer/service/flows/ProcessRedemptionPayment.kt
+++ b/service/src/main/kotlin/com/r3/corda/finance/cash/issuer/service/flows/ProcessRedemptionPayment.kt
@@ -8,6 +8,7 @@ import com.r3.corda.finance.cash.issuer.common.types.NodeTransactionStatus
 import com.r3.corda.finance.cash.issuer.common.utilities.getPendingRedemptionByNotes
 import net.corda.core.flows.FinalityFlow
 import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.FlowSession
 import net.corda.core.flows.StartableByService
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.TransactionBuilder
@@ -39,7 +40,7 @@ class ProcessRedemptionPayment(val signedTransaction: SignedTransaction) : FlowL
                 .addReferenceState(signedTransaction.tx.outRefsOfType<NostroTransactionState>().single().referenced())
                 .addCommand(NodeTransactionContract.Update(), listOf(ourIdentity.owningKey))
         val stx = serviceHub.signInitialTransaction(transactionBuilder)
-        subFlow(FinalityFlow(stx))
+        subFlow(FinalityFlow(stx, emptySet<FlowSession>()))
         logger.info(stx.tx.toString())
     }
 }

--- a/service/src/main/kotlin/com/r3/corda/finance/cash/issuer/service/flows/ReProcessNostroTransaction.kt
+++ b/service/src/main/kotlin/com/r3/corda/finance/cash/issuer/service/flows/ReProcessNostroTransaction.kt
@@ -5,6 +5,7 @@ import com.r3.corda.finance.cash.issuer.common.states.BankAccountState
 import com.r3.corda.finance.cash.issuer.common.utilities.getNostroTransactionsByAccountNumber
 import com.r3.corda.finance.cash.issuer.service.services.UpdateObserverService
 import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.InitiatingFlow
 import net.corda.core.flows.StartableByService
 
 /**
@@ -14,6 +15,7 @@ import net.corda.core.flows.StartableByService
  * access to ThreadLocal<CordaPersistence>.
  */
 @StartableByService
+@InitiatingFlow
 class ReProcessNostroTransaction(val bankAccountState: BankAccountState) : FlowLogic<Unit>() {
 
     @Suspendable

--- a/service/src/main/kotlin/com/r3/corda/finance/cash/issuer/service/flows/RedeemCashHandler.kt
+++ b/service/src/main/kotlin/com/r3/corda/finance/cash/issuer/service/flows/RedeemCashHandler.kt
@@ -29,6 +29,7 @@ class RedeemCashHandler(val otherSession: FlowSession) : FlowLogic<SignedTransac
         val cashStateAndRefsToRedeem = subFlow(ReceiveStateAndRefFlow<Cash.State>(otherSession))
         val redemptionAmount = otherSession.receive<Amount<Issued<Currency>>>().unwrap { it }
         logger.info("Received cash states to redeem.")
+        logger.info("redemptionAmount: $redemptionAmount")
         // Add create a node transaction state by adding the linearIds of all teh bank account states
         val amount = cashStateAndRefsToRedeem.map { it.state.data }.sumCash()
         val notary = serviceHub.networkMapCache.notaryIdentities.first()
@@ -61,6 +62,6 @@ class RedeemCashHandler(val otherSession: FlowSession) : FlowLogic<SignedTransac
         logger.info(transactionBuilder.toWireTransaction(serviceHub).toString())
         val partiallySignedTransaction = serviceHub.signInitialTransaction(transactionBuilder, serviceHub.keyManagementService.filterMyKeys(signers))
         val signedTransaction = subFlow(CollectSignaturesFlow(partiallySignedTransaction, listOf(otherSession)))
-        return subFlow(FinalityFlow(signedTransaction, emptySet<FlowSession>()))
+        return subFlow(FinalityFlow(signedTransaction, listOf(otherSession)))
     }
 }

--- a/service/src/main/kotlin/com/r3/corda/finance/cash/issuer/service/flows/RedeemCashHandler.kt
+++ b/service/src/main/kotlin/com/r3/corda/finance/cash/issuer/service/flows/RedeemCashHandler.kt
@@ -61,6 +61,6 @@ class RedeemCashHandler(val otherSession: FlowSession) : FlowLogic<SignedTransac
         logger.info(transactionBuilder.toWireTransaction(serviceHub).toString())
         val partiallySignedTransaction = serviceHub.signInitialTransaction(transactionBuilder, serviceHub.keyManagementService.filterMyKeys(signers))
         val signedTransaction = subFlow(CollectSignaturesFlow(partiallySignedTransaction, listOf(otherSession)))
-        return subFlow(FinalityFlow(signedTransaction))
+        return subFlow(FinalityFlow(signedTransaction, emptySet<FlowSession>()))
     }
 }

--- a/service/src/main/kotlin/com/r3/corda/finance/cash/issuer/service/flows/VerifyBankAccount.kt
+++ b/service/src/main/kotlin/com/r3/corda/finance/cash/issuer/service/flows/VerifyBankAccount.kt
@@ -2,6 +2,7 @@ package com.r3.corda.finance.cash.issuer.service.flows
 
 import co.paralleluniverse.fibers.Suspendable
 import com.r3.corda.finance.cash.issuer.common.contracts.BankAccountContract
+import com.r3.corda.finance.cash.issuer.common.flows.AbstractVerifyBankAccount
 import com.r3.corda.finance.cash.issuer.common.types.AccountNumber
 import com.r3.corda.finance.cash.issuer.common.utilities.getBankAccountStateByAccountNumber
 import net.corda.core.contracts.Command
@@ -15,7 +16,7 @@ import net.corda.core.transactions.TransactionBuilder
  */
 @StartableByService
 @StartableByRPC
-class VerifyBankAccount(val accountNumber: AccountNumber) : FlowLogic<SignedTransaction>() {
+class VerifyBankAccount(val accountNumber: AccountNumber) : AbstractVerifyBankAccount() {
 
     @Suspendable
     override fun call(): SignedTransaction {
@@ -30,7 +31,7 @@ class VerifyBankAccount(val accountNumber: AccountNumber) : FlowLogic<SignedTran
             throw FlowException("Bank account $accountNumber is already verified.")
         }
 
-        val session = initiateFlow(bankAccountState.owner)
+        val ownerSsession = initiateFlow(bankAccountState.owner)
 
         logger.info("Updating verified flag for ${bankAccountState.accountNumber}.")
         val updatedBankAccountState = bankAccountState.copy(verified = true)
@@ -41,7 +42,8 @@ class VerifyBankAccount(val accountNumber: AccountNumber) : FlowLogic<SignedTran
                 .addOutputState(updatedBankAccountState, BankAccountContract.CONTRACT_ID)
         val stx = serviceHub.signInitialTransaction(utx)
         // Share the updated bank account state with the owner.
-        return subFlow(FinalityFlow(stx, setOf(session)))
+        val sessionsForFinality = if (serviceHub.myInfo.isLegalIdentity(bankAccountState.owner)) emptyList() else listOf(ownerSsession)
+        return subFlow(FinalityFlow(stx, sessionsForFinality))
     }
 
 }

--- a/service/src/main/kotlin/com/r3/corda/finance/cash/issuer/service/services/UpdateObserverService.kt
+++ b/service/src/main/kotlin/com/r3/corda/finance/cash/issuer/service/services/UpdateObserverService.kt
@@ -83,6 +83,7 @@ class UpdateObserverService(val services: AppServiceHub) : SingletonSerializeAsT
             // TODO We probably need to reprocess here as well...
         } else {
             logger.info("We've received an account from another node.")
+            //TODO probably reprocess after verification...
             services.startFlow(ReProcessNostroTransaction(bankAccountState))
         }
     }

--- a/service/src/main/kotlin/com/r3/corda/finance/cash/issuer/service/services/UpdateObserverService.kt
+++ b/service/src/main/kotlin/com/r3/corda/finance/cash/issuer/service/services/UpdateObserverService.kt
@@ -109,11 +109,11 @@ class UpdateObserverService(val services: AppServiceHub) : SingletonSerializeAsT
         when {
             isMatched && isIssuance -> {
                 logger.info("Issuing cash!")
-                services.startFlow(IssueCash(signedTransaction))
+                services.startTrackedFlow(IssueCash(signedTransaction))
             }
             isMatched && isRedemption -> {
                 logger.info("Processing redemption payment...")
-                services.startFlow(ProcessRedemptionPayment(signedTransaction))
+                services.startTrackedFlow(ProcessRedemptionPayment(signedTransaction))
             }
         }
     }


### PR DESCRIPTION
The current version of code is incompatible with the newest Corda Core version. 
Follow Corda 4.0 **compatibility changes** are included in this PR:
- Starting with Corda 4, a ContractState must explicitly indicate which Contract it belongs to - @BelongsToContract added
- @InitiatingFlow and @Suspendable added
- Upgrade gradle, corda_gradle plugin, kotlin, quasar and log4j versions
- New Corda_gradle features "Minimum and target platform version" defined in build.gradle files
- Upgrade from fast-classpath-scanner to classgraph, because FastClasspathScanner was renamed to ClassGraph, and released as version 4. And the old Version is not compatible with Corda 4.0
- The previous FinalityFlow API is insecure and threw warnings or exceptions. Solution (s. Corda Documentation): 
"To use the new API, this flow needs to be annotated with InitiatingFlow and a FlowSession to the participant of the transaction must be passed to FinalityFlow"
- Cash Issue (IssueCash and IssueCashInternal) works
- Cash Redeem (RedeemCash and RedeemCashHandler) works